### PR TITLE
ci: bump actions/checkout to v6 and actions/setup-go to v6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,9 +7,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum


### PR DESCRIPTION
## Summary

- Updated `actions/checkout` from `v4` to `v6` (latest: v6.0.2)
- Updated `actions/setup-go` from `v5` to `v6` (latest: v6.4.0)

## Test plan

- [ ] Confirm CI workflow runs successfully on this PR