### PR TITLE
docs: add godoc comments to all exported symbols and packages

### DIFF
--- a/internal/ghclient/client.go
+++ b/internal/ghclient/client.go
@@ -1,3 +1,4 @@
+// Package ghclient provides a GitHub API client supporting both personal (PAT) and org (GitHub App) auth modes.
 package ghclient
 
 import (
@@ -23,7 +24,7 @@ const (
 
 // CommitData is a normalized commit record returned by either fetch mode.
 type CommitData struct {
-	Message string
+	Message string // full commit message
 	Repo    string // "owner/repo"
 	Author  string // GitHub login or display name
 }
@@ -93,7 +94,10 @@ func FromEnv() (*Client, error) {
 	return c, nil
 }
 
-func (c *Client) Mode() Mode   { return c.mode }
+// Mode returns the operation mode (PersonalMode or OrgMode).
+func (c *Client) Mode() Mode { return c.mode }
+
+// User returns the GitHub login or org name the client is authenticated as.
 func (c *Client) User() string { return c.user }
 
 // FetchCommits dispatches to the appropriate mode's fetch implementation.

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,3 +1,4 @@
+// Package metrics defines the Prometheus metrics exported by tacoma.
 package metrics
 
 import (
@@ -5,6 +6,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+// CommitsTotal counts commits processed, partitioned by repo, author, type, and conventional-commit flag.
 var CommitsTotal = promauto.NewCounterVec(
 	prometheus.CounterOpts{
 		Name: "gitstats_commits",

--- a/internal/persistence/file.go
+++ b/internal/persistence/file.go
@@ -12,6 +12,7 @@ type fileStore struct {
 	data map[string]float64
 }
 
+// NewFileStore returns a StateStore backed by a local JSON file at path.
 func NewFileStore(path string) (StateStore, error) {
 	s := &fileStore{path: path, data: make(map[string]float64)}
 	if err := s.loadFromDisk(); err != nil && !os.IsNotExist(err) {

--- a/internal/persistence/persistence.go
+++ b/internal/persistence/persistence.go
@@ -1,3 +1,4 @@
+// Package persistence defines the StateStore interface and its file and Redis implementations.
 package persistence
 
 import (

--- a/internal/persistence/redis.go
+++ b/internal/persistence/redis.go
@@ -14,6 +14,7 @@ type redisStore struct {
 	client *redis.Client
 }
 
+// NewRedisStore returns a StateStore backed by a Redis hash at host, authenticated with password.
 func NewRedisStore(host, password string) (StateStore, error) {
 	c := redis.NewClient(&redis.Options{
 		Addr:     host,

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -1,3 +1,4 @@
+// Package poller runs the GitHub commit polling loop and updates metrics.
 package poller
 
 import (


### PR DESCRIPTION
## Summary
- Add package-level doc comments to all four internal packages (`ghclient`, `metrics`, `persistence`, `poller`)
- Add godoc comments to previously undocumented exported symbols: `Client.Mode()`, `Client.User()`, `CommitData.Message`, `CommitsTotal`, `NewFileStore`, and `NewRedisStore`

## Test plan
- [ ] `go vet ./...` passes
- [ ] `go build ./...` passes
- [ ] `go doc ./internal/ghclient`, `./internal/metrics`, `./internal/persistence`, `./internal/poller` each show package and symbol docs