### PR TITLE
feat: add grafana service and github setup docs

### DIFF
--- a/GITHUB.md
+++ b/GITHUB.md
@@ -1,0 +1,87 @@
+# Personal Mode
+
+Personal mode authenticates as a GitHub user via a Personal Access Token (PAT) and tracks that user's contributions using the GraphQL `contributionsCollection` API.
+
+## Creating a Personal Access Token
+
+1. Go to **github.com → Settings → Developer settings → Personal access tokens → Tokens (classic)**
+2. Click **Generate new token (classic)**
+3. Set a descriptive note (e.g. `gitstats`)
+4. Set an expiration appropriate for your use case
+5. Select the minimum required scope:
+
+| Scope | Required | Reason |
+|---|---|---|
+| `read:user` | Yes | Grants access to the GraphQL `contributionsCollection` query |
+| `repo` | Only for private repos | Required to include commits from private repositories |
+
+6. Click **Generate token** and copy the value immediately
+
+> **Note:** Fine-grained PATs are not recommended for personal mode. The `contributionsCollection` query is a user-level GraphQL operation that maps cleanly to the classic PAT `read:user` scope.
+
+## Configuration
+
+Set in `.env`:
+
+```
+GITHUB_PAT=ghp_...
+GITHUB_USER=your-github-login
+```
+
+---
+
+# Org Mode
+
+Org mode uses a GitHub App to authenticate and tracks commits across all non-archived repositories in an organization.
+
+## Creating a GitHub App
+
+1. Go to **github.com → Your Organization → Settings → Developer settings → GitHub Apps → New GitHub App**
+2. Fill in the required fields:
+   - **GitHub App name**: any name (e.g. `gitstats`)
+   - **Homepage URL**: any URL (required by GitHub; not used by this app)
+3. Under **Webhook**, uncheck **Active** — webhooks are not used
+4. Under **Repository permissions**, set only:
+
+| Permission | Level | Reason |
+|---|---|---|
+| Metadata | Read-only | Required for all GitHub Apps; needed to list repositories |
+| Contents | Read-only | Required to read commits from repositories |
+
+5. Leave all other permissions at **No access**
+6. Under **Where can this GitHub App be installed?**, select **Only on this account**
+7. Click **Create GitHub App**
+8. Note the **App ID** displayed at the top of the app settings page
+
+## Generating a Private Key
+
+1. On the app settings page, scroll to **Private keys**
+2. Click **Generate a private key**
+3. A `.pem` file is downloaded — store it securely
+
+## Installing the App
+
+1. On the app settings page, click **Install App** in the left sidebar
+2. Click **Install** next to your organization
+3. Choose **All repositories** (or select specific ones)
+4. Click **Install**
+5. After installation, the URL will be of the form:
+   ```
+   https://github.com/organizations/<org>/settings/installations/<installation-id>
+   ```
+   Note the **Installation ID** from the URL
+
+## Configuration
+
+Set in `.env`:
+
+```
+GITHUB_APP_ID=123456
+GITHUB_APP_INSTALLATION_ID=78901234
+GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----
+MIIEow...
+-----END RSA PRIVATE KEY-----"
+GITHUB_ORG=your-org-name
+```
+
+> **Note:** `GITHUB_APP_PRIVATE_KEY` must contain the full PEM content with literal newlines preserved. In a `.env` file, wrap the value in double quotes.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A GitHub commit metrics exporter. Polls GitHub for commit activity and exposes P
 
 **Org** — tracks all non-archived repos in a GitHub org via GitHub App auth. Set `GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, `GITHUB_APP_PRIVATE_KEY`, and `GITHUB_ORG`.
 
+See [GitHub Setup](GITHUB.md) for token and App credential instructions.
+
 ## Environment Variables
 
 | Variable | Description |

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,3 +20,15 @@ services:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
     ports:
       - "9090:9090"
+
+  grafana:
+    image: grafana/grafana:11.1.0
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus

--- a/grafana/provisioning/datasources/prometheus.yaml
+++ b/grafana/provisioning/datasources/prometheus.yaml
@@ -1,0 +1,10 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    url: http://prometheus:9090
+    access: proxy
+    isDefault: true
+    jsonData:
+      httpMethod: POST


### PR DESCRIPTION
## Summary

- Adds a pre-configured Grafana service (`grafana/grafana:11.1.0`) to `docker-compose.yaml`, wired to the existing Prometheus service via datasource provisioning — no manual setup required after `docker compose up`
- Adds `grafana/provisioning/datasources/prometheus.yaml` to auto-provision Prometheus at `http://prometheus:9090` as the default datasource on Grafana startup
- Adds `GITHUB.md` documenting least-privilege credential setup for both Personal mode (classic PAT with `read:user` scope) and Org mode (GitHub App with Metadata + Contents read-only permissions)
- Updates `README.md` with a reference link to `GITHUB.md`

## Test plan

- [ ] `docker compose up --build` starts all three services without errors
- [ ] `http://localhost:3000` (admin/admin) shows Grafana with Prometheus pre-configured as the default datasource
- [ ] Datasource "Save & Test" passes in Grafana UI
- [ ] `GITHUB.md` renders correctly on GitHub with both H1 sections